### PR TITLE
Fix: Add missing google-ads-api-report-fetcher dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN pip install "poetry==1.7.1"
 #    If poetry.lock doesn't exist, only pyproject.toml will be copied.
 #    This order is important to leverage Docker layer caching.
 COPY pyproject.toml poetry.lock* ./
+RUN poetry lock --no-update
 
 # 5. Run poetry install --no-root --no-dev
 #    This ensures only production dependencies are installed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ yfinance = "^0.2.56"
 psutil = "^5.9.5"
 absl-py = "^2.1.0"
 cloudpickle = "^3.0.0"
+google-ads-api-report-fetcher = "^0.1.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
The application was failing to deploy to Vertex AI because the `google.adk.cli` module, executed by the Docker CMD, could not be found. This was due to the `google-ads-api-report-fetcher` package (which provides `google.adk.cli`) not being listed in `pyproject.toml`.

This commit:
- Adds `google-ads-api-report-fetcher` to the project dependencies in `pyproject.toml`.
- Modifies the `Dockerfile` to run `poetry lock --no-update` after copying `pyproject.toml` and `poetry.lock*`. This ensures that the lock file is synchronized with `pyproject.toml` during the build, capturing the new dependency before `poetry install` is executed.

You will need to update your local `poetry.lock` file and then rebuild and redeploy the application.