### PR TITLE
Fix: Use direct path for ADK executable in Docker CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ ENV PORT=8080
 EXPOSE 8080
 
 # 10. Use poetry run directly with the working command
-CMD ["poetry", "run", "adk", "run", "predictvet"]
+CMD ["/app/.venv/bin/adk", "run", "predictvet"]


### PR DESCRIPTION
The application was failing to deploy on Cloud Run with an 'error finding executable "adk" in PATH'. This was likely due to an issue with how `poetry run` was resolving the path for the `adk` executable within the container environment.

This commit modifies the Dockerfile's CMD instruction to use the direct path to the `adk` executable located within the Poetry virtual environment (`/app/.venv/bin/adk`). This explicit path ensures the executable is found and bypasses potential PATH resolution issues with `poetry run`.