### PR TITLE
Fix: Configure ADK agent to listen on port 8080 for Cloud Run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,10 @@ COPY predictvet/ ./predictvet/
 
 # 8. Set environment variables for the ADK agent
 ENV ADK_AGENT_NAME=predictvet
-ENV PORT=8000
+ENV PORT=8080
 
-# 9. Expose port 8000
-EXPOSE 8000
+# 9. Expose port 8080
+EXPOSE 8080
 
 # 10. Define the command to run the agent as an API server
-CMD ["/app/.venv/bin/adk", "api_server", "--app_folder", "predictvet", "--port", "8000"]
+CMD ["/app/.venv/bin/adk", "api_server", "--app_folder", "predictvet", "--port", "8080"]


### PR DESCRIPTION
The ADK agent was previously configured to listen on port 8000. This commit updates the Dockerfile to ensure the agent listens on port 8080, which is the standard expected by Cloud Run.

Changes made:
- Updated `ENV PORT` to `8080`.
- Updated `EXPOSE` to `8080`.
- Updated the `CMD` instruction to pass `--port 8080` to the `adk api_server`.

This change aligns the application with Cloud Run's requirements and ensures proper deployment and execution.